### PR TITLE
new readFile function to return vector<char> 

### DIFF
--- a/File.cpp
+++ b/File.cpp
@@ -118,6 +118,23 @@ void File::readFile(const std::string& filename, void* s, int len)
     fclose(fp);
 }
 
+std::vector<char> File::readFileVecChar(const std::string& filename)
+{
+	FILE* fp = fopen(filename.c_str(), "rb");
+	if (!fp)
+	{
+		fprintf(stderr, "Cannot open file %s\n", filename.c_str());
+		return {};
+	}
+	fseek(fp, 0, SEEK_END);
+	int length = ftell(fp);
+	fseek(fp, 0, 0);
+	std::vector<char> s(length, '\0');
+	fread(s.data(), length, 1, fp);
+	fclose(fp);
+	return s;
+}
+
 int File::writeFile(const std::string& filename, void* s, int len)
 {
     FILE* fp = fopen(filename.c_str(), "wb");

--- a/File.cpp
+++ b/File.cpp
@@ -120,19 +120,19 @@ void File::readFile(const std::string& filename, void* s, int len)
 
 std::vector<char> File::readFileVecChar(const std::string& filename)
 {
-	FILE* fp = fopen(filename.c_str(), "rb");
-	if (!fp)
-	{
-		fprintf(stderr, "Cannot open file %s\n", filename.c_str());
-		return {};
-	}
-	fseek(fp, 0, SEEK_END);
-	int length = ftell(fp);
-	fseek(fp, 0, 0);
-	std::vector<char> s(length, '\0');
-	fread(s.data(), length, 1, fp);
-	fclose(fp);
-	return s;
+    FILE* fp = fopen(filename.c_str(), "rb");
+    if (!fp)
+    {
+        fprintf(stderr, "Cannot open file %s\n", filename.c_str());
+        return {};
+    }
+    fseek(fp, 0, SEEK_END);
+    int length = ftell(fp);
+    fseek(fp, 0, 0);
+    std::vector<char> s(length, '\0');
+    fread(s.data(), length, 1, fp);
+    fclose(fp);
+    return s;
 }
 
 int File::writeFile(const std::string& filename, void* s, int len)

--- a/File.h
+++ b/File.h
@@ -17,7 +17,7 @@ public:
 
     static bool readFile(const std::string& filename, char** s, int* len);
     static void readFile(const std::string& filename, void* s, int len);
-	static std::vector<char> readFileVecChar(const std::string& filename);
+    static std::vector<char> readFileVecChar(const std::string& filename);
     static int writeFile(const std::string& filename, void* s, int len);
 
     template <class T>

--- a/File.h
+++ b/File.h
@@ -17,6 +17,7 @@ public:
 
     static bool readFile(const std::string& filename, char** s, int* len);
     static void readFile(const std::string& filename, void* s, int len);
+	static std::vector<char> readFileVecChar(const std::string& filename);
     static int writeFile(const std::string& filename, void* s, int len);
 
     template <class T>

--- a/File.h
+++ b/File.h
@@ -40,11 +40,8 @@ public:
     template <class T>
     static void readFileToVector(std::string filename, std::vector<T>& v)
     {
-        char* buffer;
-        int length;
-        readFile(filename, &buffer, &length);
-        readDataToVector(buffer, length, v);
-        delete[] buffer;
+        auto buffer = readFileVecChar(filename);
+        readDataToVector(buffer.data(), buffer.size(), v);
     }
 
     template <class T>


### PR DESCRIPTION
new readFile function to return vector<char>
This function can be used to eliminate problems such as https://github.com/scarsty/kys-cpp/pull/8. 

old style of reading a file (along with returning length) into a byte array
```
char* s;
int l;
File::readFile("some/file", &s, &l);
for (int i = 0; i < l; i++) 
{
    // pointer arithmetic
    // s + offset[i]
}
delete[] s;
```

with the new function, we can do the following

```
auto s = File::readFileVecChar("some/file");
for (int i = 0; i < s.size(); i++) 
{
    // pointer arithmetic
    // s.data() + offset[i] or &s[0] + offset[i] or &s[offset[i]]
}
```

Note: with C++11 move semantics, returning a vector<char>(instead of passing in a pointer/reference) does not occur any extra copying cost 