### PR TITLE
修复Mac编译问题

### DIFF
--- a/File.cpp
+++ b/File.cpp
@@ -11,7 +11,9 @@
 #include <strsafe.h>
 #else
 #include "dirent.h"
+#ifndef __APPLE__
 #include <sys/io.h>
+#endif
 #include <sys/uio.h>
 #include <unistd.h>
 #define _mkdir(p) mkdir(p, S_IRWXU)


### PR DESCRIPTION
MacOS C库没有 sys/io.h 这个头文件，编译时会报错`'sys/io.h' file not found`，去掉就可以编过。