### PR TITLE
fix typos in filefunc.h function naming

### DIFF
--- a/filefunc.cpp
+++ b/filefunc.cpp
@@ -430,7 +430,7 @@ std::string filefunc::getParentPath(const std::string& filename, int utf8)
     return "";
 }
 
-std::string filefunc::toLegalFileanme(const std::string& filename, int allow_path)
+std::string filefunc::toLegalFilename(const std::string& filename, int allow_path)
 {
     std::string f = filename, chars = " *<>?|:";
     if (!allow_path)

--- a/filefunc.h
+++ b/filefunc.h
@@ -61,7 +61,7 @@ std::string getFileMainname(const std::string& filename);
 std::string getFilenameWithoutPath(const std::string& filename);
 std::string changeFileExt(const std::string& filename, const std::string& ext);
 std::string getParentPath(const std::string& filename, int utf8 = 0);    //utf8 has no effect on non-win32
-std::string toLegalFileanme(const std::string& filename, int allow_path = 1);
+std::string toLegalFilename(const std::string& filename, int allow_path = 1);
 bool compareNature(const std::string& a, const std::string& b);
 
 }    //namespace filefunc


### PR DESCRIPTION
API 命名中的 typo 的修正